### PR TITLE
Allow emitter.once()

### DIFF
--- a/eventflow.js
+++ b/eventflow.js
@@ -75,6 +75,9 @@ var eventflow = module.exports = function eventflow (eventEmitter) {
 };
 
 function asyncApply (thisArg, fn, args, done) {
+  if ('function' === typeof fn.removeWrapper) {
+    fn.removeWrapper(); // remove the wrapper, as it would have removed itself
+  }
   if (!Array.isArray(args)) args = [args];
   if (fn.length <= args.length) {
     var result = fn.apply(thisArg, args);
@@ -111,7 +114,7 @@ function handleOnce (emitter, name, listener) {
   // If there is no such property, it's a normal .on listener -- proceed as normal
   if (typeof listener.listener !== 'function') return listener;
   var origlistener = listener.listener;
-  emitter.removeListener(name, listener); // remove the wrapper, as it would have removed itself
+  origlistener.removeWrapper = emitter.removeListener.bind(emitter, name, listener); // save this removal function for execution time
   return origlistener; // apply to the original listener; note that since the .once wrapper
                        // was removed, it won't get invoked again
 }

--- a/eventflow.js
+++ b/eventflow.js
@@ -63,10 +63,10 @@ var eventflow = module.exports = function eventflow (eventEmitter) {
     }
     else {
       if (callback) {
-        asyncApply(emitter, listeners[0], args, callback);
+        asyncApply(emitter, handleOnce(emitter, name, listeners[0]), args, callback);
       }
       else {
-        return listeners[0].apply(emitter, args);
+        return handleOnce(emitter, name, listeners[0]).apply(emitter, args);
       }
     }
   };

--- a/test/basic.js
+++ b/test/basic.js
@@ -27,12 +27,16 @@ describe('series', function() {
       result.push('c');
     });
 
-    emitter.once('foo', function (cb) {
+    emitter.once('foo', function () {
       result.push('d');
+    });
+
+    emitter.once('foo', function (cb) {
+      result.push('e');
       cb();
     });
 
-    assert.equal(emitter.listeners('foo').length, 4);
+    assert.equal(emitter.listeners('foo').length, 5);
 
     emitter.series('foo', function () {
       assert.equal(emitter.listeners('foo').length, 3);
@@ -40,6 +44,7 @@ describe('series', function() {
       assert.equal(result[1], 'b');
       assert.equal(result[2], 'c');
       assert.equal(result[3], 'd');
+      assert.equal(result[4], 'e');
       result = [];
       emitter.series('foo', function () {
         assert.equal(emitter.listeners('foo').length, 3);
@@ -64,12 +69,39 @@ describe('series', function() {
       cb();
     });
 
+    emitter.once('bar', function (a, b) {
+      result.push(a);
+      result.push(b);
+    });
+
+    emitter.once('bar', function (a, b, cb) {
+      result.push(a);
+      result.push(b);
+      cb();
+    });
+
+    assert.equal(emitter.listeners('bar').length, 4);
+
     emitter.series('bar', 'foo', 'baz', function () {
+      assert.equal(emitter.listeners('bar').length, 2);
       assert.equal(result[0], 'foo');
       assert.equal(result[1], 'baz');
       assert.equal(result[2], 'foo');
       assert.equal(result[3], 'baz');
-      done();
+      assert.equal(result[4], 'foo');
+      assert.equal(result[5], 'baz');
+      assert.equal(result[6], 'foo');
+      assert.equal(result[7], 'baz');
+      result = [];
+      emitter.series('bar', 'foo', 'baz', function () {
+        assert.equal(emitter.listeners('bar').length, 2);
+        assert.equal(result[0], 'foo');
+        assert.equal(result[1], 'baz');
+        assert.equal(result[2], 'foo');
+        assert.equal(result[3], 'baz');
+        assert.equal(result.length, 4);
+        done();
+      });
     });
   });
 
@@ -80,10 +112,18 @@ describe('series', function() {
     emitter.on('fruit', function () {
       return 'orange';
     });
+    emitter.once('fruit', function (cb) {
+      cb(null, 'grape');
+    });
+    emitter.once('fruit', function () {
+      return 'lime';
+    });
     emitter.series('fruit', function (err, results) {
       assert.ifError(err);
       assert.equal(results[0], 'apple');
       assert.equal(results[1], 'orange');
+      assert.equal(results[2], 'grape');
+      assert.equal(results[3], 'lime');
       done();
     });
   });
@@ -91,6 +131,9 @@ describe('series', function() {
   it('should support optional use of `error`', function (done) {
     emitter.on('drink', function () {
       result.push('coke');
+    });
+    emitter.once('drink', function (cb) {
+      cb('oh no! first');
     });
     emitter.on('drink', function (cb) {
       cb('oh no!');
@@ -101,18 +144,30 @@ describe('series', function() {
     emitter.series('drink', function (err) {
       assert.equal(result[0], 'coke');
       assert.equal(result.length, 1);
-      assert.equal(err, 'oh no!');
-      done();
+      assert.equal(err, 'oh no! first');
+      result = [];
+      emitter.series('drink', function (err) {
+        assert.equal(result[0], 'coke');
+        assert.equal(result.length, 1);
+        assert.equal(err, 'oh no!');
+        done();
+      });
     });
   });
 
   it('should support sync listeners returning errors', function (done) {
+    emitter.once('eat', function () {
+      return new Error('I am not really hungry...');
+    });
     emitter.on('eat', function () {
       return new Error('I am full');
     });
     emitter.series('eat', function (err, results) {
-      assert.equal(err.message, 'I am full');
-      done();
+      assert.equal(err.message, 'I am not really hungry...');
+      emitter.series('eat', function (err, results) {
+        assert.equal(err.message, 'I am full');
+        done();
+      });
     });
   });
 });
@@ -133,9 +188,18 @@ describe('parallel', function () {
       result.hard = 'Jolly Rancher';
       cb();
     });
+    emitter.on('candy', function () {
+      result.boring = 'Hershey Bar';
+    });
+    emitter.on('candy', function (cb) {
+      result.perfect = 'Peanut Butter Cup';
+      cb();
+    });
     emitter.parallel('candy', function () {
       assert.equal(result.sour, 'Sour Patch');
       assert.equal(result.hard, 'Jolly Rancher');
+      assert.equal(result.boring, 'Hershey Bar');
+      assert.equal(result.perfect, 'Peanut Butter Cup');
       done();
     });
   });
@@ -147,12 +211,21 @@ describe('parallel', function () {
     emitter.on('numbers', function() {
       return 2;
     });
+    emitter.once('numbers', function() {
+      return 3;
+    });
+    emitter.once('numbers', function() {
+      return 4;
+    });
     emitter.parallel('numbers', function (err, results) {
       assert.ifError(err);
       assert.equal(results[1], 2);
+      assert.equal(results[3], 4);
+      assert.equal(results.length, 4);
       emitter.parallel('numbers', function (err, results) {
         assert.ifError(err);
         assert.equal(results[0], 1);
+        assert.equal(results.length, 2);
         done();
       });
     });
@@ -180,7 +253,7 @@ describe('invoke', function () {
     });
   });
 
-  it('should work when there is exactly one synchronous listner', function (done) {
+  it('should work when there is exactly one synchronous listener', function (done) {
     var timestamp = new Date().getTime();
     emitter.on('timestamp', function () {
       return timestamp;
@@ -189,6 +262,21 @@ describe('invoke', function () {
       assert.ifError(err);
       assert.equal(value, timestamp);
       done();
+    });
+  });
+
+  it('should work exactly once when there is exactly one synchronous .once listener', function (done) {
+    var timestamp = new Date().getTime();
+    emitter.once('timestamp', function () {
+      return timestamp;
+    });
+    emitter.invoke('timestamp', function (err, value) {
+      assert.ifError(err);
+      assert.equal(value, timestamp);
+      emitter.invoke('timestamp', function (err, value) {
+        assert(err);
+        done();
+      });
     });
   });
 
@@ -201,6 +289,21 @@ describe('invoke', function () {
       assert.ifError(err);
       assert.equal(value, timestamp);
       done();
+    });
+  });
+
+  it('should work exactly once when there is exactly one asynchronous .once listener', function (done) {
+    var timestamp = new Date().getTime();
+    emitter.once('timestamp', function (callback) {
+      callback(null, timestamp);
+    });
+    emitter.invoke('timestamp', function (err, value) {
+      assert.ifError(err);
+      assert.equal(value, timestamp);
+      emitter.invoke('timestamp', function (err, value) {
+        assert(err);
+        done();
+      });
     });
   });
 
@@ -220,6 +323,29 @@ describe('invoke', function () {
       callback(null, a - b);
     });
     emitter.invoke('subtract', 3, 2, function (err, value) {
+      assert.ifError(err);
+      assert.equal(value, 1);
+      done();
+    });
+  });
+
+  it('should work with arguments using .once listener', function (done) {
+    emitter.once('multiply', function (a, b) {
+      return a * b;
+    });
+    emitter.invoke('multiply', 2, 3, function (err, value) {
+      assert.ifError(err);
+      assert.equal(value, 6);
+      done();
+    });
+  });
+
+  it('should work with arguments, asynchronously, using .once listener', function (done) {
+    emitter.once('modulus', function (a, b, callback) {
+      // You thought I was going to divide, didn't you?
+      callback(null, a % b);
+    });
+    emitter.invoke('modulus', 3, 2, function (err, value) {
       assert.ifError(err);
       assert.equal(value, 1);
       done();
@@ -246,6 +372,10 @@ describe('invoke', function () {
       return 'isSync';
     });
     assert.equal(emitter.invoke('sync'), 'isSync');
+    emitter.once('resync', function () {
+      return 'isSync';
+    });
+    assert.equal(emitter.invoke('resync'), 'isSync');
   });
 });
 
@@ -256,6 +386,25 @@ describe('waterfall', function() {
     });
 
     emitter.on('foo', function (n, cb) {
+      cb(null, n * 5);
+    });
+
+    emitter.on('foo', function (n) {
+      return n - 3;
+    });
+
+    emitter.waterfall('foo', 0, function (err, n) {
+      assert.equal(n, 2);
+      done();
+    });
+  });
+
+  it('should work with one or more .once handlers', function (done) {
+    emitter.once('foo', function (n) {
+      return n + 1;
+    });
+
+    emitter.once('foo', function (n, cb) {
       cb(null, n * 5);
     });
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -27,11 +27,28 @@ describe('series', function() {
       result.push('c');
     });
 
+    emitter.once('foo', function (cb) {
+      result.push('d');
+      cb();
+    });
+
+    assert.equal(emitter.listeners('foo').length, 4);
+
     emitter.series('foo', function () {
+      assert.equal(emitter.listeners('foo').length, 3);
       assert.equal(result[0], 'a');
       assert.equal(result[1], 'b');
       assert.equal(result[2], 'c');
-      done();
+      assert.equal(result[3], 'd');
+      result = [];
+      emitter.series('foo', function () {
+        assert.equal(emitter.listeners('foo').length, 3);
+        assert.equal(result[0], 'a');
+        assert.equal(result[1], 'b');
+        assert.equal(result[2], 'c');
+        assert.equal(result.length, 3);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Currently, using `emitter.once()` with a callback will fail with `TypeError: undefined is not a function`. This makes it work.

The test is rather ugly, but it is demonstrative.

I'm not sure it makes a lot of sense to use `.once()` in a flow control scenario (unless ALL the listeners are only firing once), but I don't think the current failure mode is quite expected behavior.
